### PR TITLE
Expose `parse` and `HttpStatusError` on exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 const ModelHandler = require('./src/handler');
+const { HttpStatusError } = require('./src/errors');
+const { parse } = require('./src/parser');
 
 module.exports = {
-    ModelHandler
+    ModelHandler,
+    HttpStatusError,
+    parse
 };


### PR DESCRIPTION
This makes it possible to override individual handler functions
while still being able to take advantage of all of the url parsing
logic.