### PR TITLE
Accept query params in findOne and make handlers testable

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -11,7 +11,7 @@ class ModelHandler {
     
     create() {
         const handle = (req, res, next) => {
-            this.model
+            return this.model
                 .create(req.body)
                 .then(respond)
                 .catch(next);
@@ -30,7 +30,7 @@ class ModelHandler {
     
     get() {
         const handle = (req, res, next) => {
-            this
+            return this
                 .findOne(Object.assign({},req.query,req.params))
                 .then(respond)
                 .catch(next);
@@ -52,7 +52,7 @@ class ModelHandler {
     
     query() {
         const handle = (req, res, next) => {
-            this
+            return this
                 .findAndCountAll(req.query)
                 .then(respond)
                 .catch(next);
@@ -78,7 +78,7 @@ class ModelHandler {
     
     remove() {
         const handle = (req, res, next) => {
-            this
+            return this
                 .findOne(req.params)
                 .then(destroy)
                 .then(respond)
@@ -104,7 +104,7 @@ class ModelHandler {
     
     update() {
         const handle = (req, res, next) => {
-            this
+            return this
                 .findOne(Object.assign({},req.query,req.params))
                 .then(updateAttributes)
                 .then(respond)

--- a/src/handler.js
+++ b/src/handler.js
@@ -8,74 +8,74 @@ class ModelHandler {
         this.model = model;
         this.defaults = defaults;
     }
-
+    
     create() {
         const handle = (req, res, next) => {
             this.model
                 .create(req.body)
                 .then(respond)
                 .catch(next);
-
+            
             function respond(row) {
                 res.status(201);
                 res.send(res.transform(row));
             }
         };
-
+        
         return [
             raw,
             handle
         ];
     }
-
+    
     get() {
         const handle = (req, res, next) => {
             this
                 .findOne(Object.assign({},req.query,req.params))
                 .then(respond)
                 .catch(next);
-
+            
             function respond(row) {
                 if (!row) {
                     throw new HttpStatusError(404, 'Not Found');
                 }
-
+                
                 res.send(res.transform(row));
             }
         };
-
+        
         return [
             raw,
             handle
         ];
     }
-
+    
     query() {
         const handle = (req, res, next) => {
             this
                 .findAndCountAll(req.query)
                 .then(respond)
                 .catch(next);
-
+            
             function respond({ rows, start, end, count }) {
                 res.set('Content-Range', `${start}-${end}/${count}`);
-
+                
                 if (count > end) {
                     res.status(206);
                 } else {
                     res.status(200);
                 }
-
+                
                 res.send(res.transform(rows));
             }
         };
-
+        
         return [
             raw,
             handle
         ];
     }
-
+    
     remove() {
         const handle = (req, res, next) => {
             this
@@ -83,25 +83,25 @@ class ModelHandler {
                 .then(destroy)
                 .then(respond)
                 .catch(next);
-
+            
             function destroy(row) {
                 if (!row) {
                     throw new HttpStatusError(404, 'Not Found');
                 }
-
+                
                 return row.destroy();
             }
-
+            
             function respond() {
                 res.sendStatus(204);
             }
         };
-
+        
         return [
             handle
         ];
     }
-
+    
     update() {
         const handle = (req, res, next) => {
             this
@@ -109,48 +109,48 @@ class ModelHandler {
                 .then(updateAttributes)
                 .then(respond)
                 .catch(next);
-
+                
             function updateAttributes(row) {
                 if (!row) {
                     throw new HttpStatusError(404, 'Not Found');
                 }
-
+                
                 return row.updateAttributes(req.body);
             }
-
+            
             function respond(row) {
                 res.send(res.transform(row));
             }
         };
-
+        
         return [
             raw,
             handle
         ];
     }
-
+    
     findOne(params, options) {
         options = _.merge(parse(params, this.model), options);
 
         return this.model.findOne(options);
     }
-
+    
     findAndCountAll(params, options) {
         let parsed = parse(params, this.model);
-
+        
         options = _(parsed)
             .defaults(this.defaults)
             .merge(options)
             .value();
-
+        
         return this.model
             .findAndCountAll(options)
             .then(extract);
-
+            
         function extract({ count, rows }) {
             const start = options.offset;
             const end = Math.min(count, (options.offset + options.limit) || count);
-
+        
             return { rows, start, end, count };
         }
     }

--- a/src/handler.js
+++ b/src/handler.js
@@ -8,74 +8,74 @@ class ModelHandler {
         this.model = model;
         this.defaults = defaults;
     }
-    
+
     create() {
         const handle = (req, res, next) => {
             this.model
                 .create(req.body)
                 .then(respond)
                 .catch(next);
-            
+
             function respond(row) {
                 res.status(201);
                 res.send(res.transform(row));
             }
         };
-        
+
         return [
             raw,
             handle
         ];
     }
-    
+
     get() {
         const handle = (req, res, next) => {
             this
-                .findOne(req.params)
+                .findOne(Object.assign({},req.query,req.params))
                 .then(respond)
                 .catch(next);
-            
+
             function respond(row) {
                 if (!row) {
                     throw new HttpStatusError(404, 'Not Found');
                 }
-                
+
                 res.send(res.transform(row));
             }
         };
-        
+
         return [
             raw,
             handle
         ];
     }
-    
+
     query() {
         const handle = (req, res, next) => {
             this
                 .findAndCountAll(req.query)
                 .then(respond)
                 .catch(next);
-            
+
             function respond({ rows, start, end, count }) {
                 res.set('Content-Range', `${start}-${end}/${count}`);
-                
+
                 if (count > end) {
                     res.status(206);
                 } else {
                     res.status(200);
                 }
-                
+
                 res.send(res.transform(rows));
             }
         };
-        
+
         return [
             raw,
             handle
         ];
     }
-    
+
     remove() {
         const handle = (req, res, next) => {
             this
@@ -83,74 +83,74 @@ class ModelHandler {
                 .then(destroy)
                 .then(respond)
                 .catch(next);
-            
+
             function destroy(row) {
                 if (!row) {
                     throw new HttpStatusError(404, 'Not Found');
                 }
-                
+
                 return row.destroy();
             }
-            
+
             function respond() {
                 res.sendStatus(204);
             }
         };
-        
+
         return [
             handle
         ];
     }
-    
+
     update() {
         const handle = (req, res, next) => {
             this
-                .findOne(req.params)
+                .findOne(Object.assign({},req.query,req.params))
                 .then(updateAttributes)
                 .then(respond)
                 .catch(next);
-                
+
             function updateAttributes(row) {
                 if (!row) {
                     throw new HttpStatusError(404, 'Not Found');
                 }
-                
+
                 return row.updateAttributes(req.body);
             }
-            
+
             function respond(row) {
                 res.send(res.transform(row));
             }
         };
-        
+
         return [
             raw,
             handle
         ];
     }
-    
+
     findOne(params, options) {
         options = _.merge(parse(params, this.model), options);
 
         return this.model.findOne(options);
     }
-    
+
     findAndCountAll(params, options) {
         let parsed = parse(params, this.model);
-        
+
         options = _(parsed)
             .defaults(this.defaults)
             .merge(options)
             .value();
-        
+
         return this.model
             .findAndCountAll(options)
             .then(extract);
-            
+
         function extract({ count, rows }) {
             const start = options.offset;
             const end = Math.min(count, (options.offset + options.limit) || count);
-        
+
             return { rows, start, end, count };
         }
     }


### PR DESCRIPTION
Previously, something like this would not actually pass the `includes` query param to the Sequelize query, as only the named path params in `req.params` were being passed:

GET `/model/1?includes=RelatedObjects`

Combining and passing both the `request.params` and `request.query` objects allows me to query for a single object and define the related includes I want passed back.

Also, I made the handler functions return the promise chains inside of them so unit tests calling them can await the promise resolution.